### PR TITLE
Remove missed AndAnd dependency

### DIFF
--- a/lib/resource_model/base.rb
+++ b/lib/resource_model/base.rb
@@ -503,13 +503,13 @@ class ResourceModel::Base
       hash[attribute_name] = self.send(attribute_name)
     end
     self.class.decimal_attributes.each do |attribute_name|
-      hash[attribute_name] = self.send(attribute_name).andand.to_s
+      hash[attribute_name] = self.send(attribute_name)&.to_s
     end
     self.class.usd_attributes.each do |attribute_name|
-      hash[attribute_name] = self.send(attribute_name).andand.to_s
+      hash[attribute_name] = self.send(attribute_name)&.to_s
     end
     self.class.date_attributes.each do |attribute_name|
-      hash[attribute_name] = self.send(attribute_name).andand.iso8601
+      hash[attribute_name] = self.send(attribute_name)&.iso8601
     end
     self.class.string_attributes.each do |attribute_name|
       hash[attribute_name] = self.send(attribute_name)

--- a/resource_model.gemspec
+++ b/resource_model.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.3"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 


### PR DESCRIPTION
This gem includes 3 references to the [AndAnd gem](https://github.com/raganwald/andand), but this dependency isn't noted in the gemspec. Whoops!

Rather than adding the dependency, this change removes the use of `.andand` and updates the required Ruby version to 2.3+. Ruby introduced the `&.` operator & `.dig` helper in version 2.3, which serve the same purpose as `.andand` without the additional dependency. As 2.3 is officially EOL, it's a safe place to start as a required minimum version.